### PR TITLE
Rastreadores globo

### DIFF
--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -1,4 +1,8 @@
 &zoneid=*&ad_$popup
+! GLOBO
+||recomendacao.globo.com
+||globo-ab.globo.com
+||cocoon.globo.com
 .openx.$domain=~openx.com
 .php?zoneid=
 /?zoneid

--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -19,7 +19,7 @@
 ||glbimg.com^*/tv4.min.js
 ||glbimg.com^*/video-recommendation-plugin.js
 ||glbimg.com^*/youboralib*.js
-||glbimg.com^*/glb-pv-min.js
+||glbimg.com^*/glb*pv*min.js
 ||glbimg.com^*/comScore*.js
 ||glbimg.com^*/settings.min.js
 

--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -1,8 +1,40 @@
-&zoneid=*&ad_$popup
 ! GLOBO
 ||recomendacao.globo.com
 ||globo-ab.globo.com
 ||cocoon.globo.com
+||sentry.globoi.com
+!! RASTREADORES HORIZON, GA, FACEBOOK E COOKIES
+!! PODEM SER SERVIDOS ATRÁVES DE VÁRIOS CDN DIFERENTES
+||glbimg.com^*/horizon-client-js.min.js
+||glbimg.com^*/profiling.min.js
+||glbimg.com^*/horizon-client-js.min.js
+||glbimg.com^*/4c1064b084af3049b2b15cc8c22692c4.js
+||glbimg.com^*/globo-ab-v2.min.js
+||glbimg.com^*/globo-ab.min.js
+||glbimg.com^*/glb-rt.js
+
+!! OUTROS RASTREADORES E/OU ABORRECIMENTOS
+||glbimg.com^*/growth.min.js
+||glbimg.com^*/lgpd-lib.min.js
+||glbimg.com^*/tv4.min.js
+||glbimg.com^*/video-recommendation-plugin.js
+||glbimg.com^*/youboralib*.js
+||glbimg.com^*/glb-pv-min.js
+||glbimg.com^*/comScore*.js
+||glbimg.com^*/settings.min.js
+
+!! NECESSÁRIO PARA LIVES, BARRA LATERAL, LOGIN, WORKERS, NOTIFICAÇÕES ETC
+!! PORÉM TAMBÉM PODEM CARREGAR OUTRAS COISAS INDESEJADAS
+!||glbimg.com^*/barra-globocom.min.js
+!||glbimg.com^*/97c0cd02f8bf5cf87fc2f141ea3cf79f.js
+!||glbimg.com^*/e24076c3c6525fdff13b4b62104d4934.js
+!||glbimg.com^*/bastian*.js
+!||glbimg.com^*/api/*/api.min.js
+!||glbimg.com^*/cadun.js
+
+!! end GLOBO
+
+&zoneid=*&ad_$popup
 .openx.$domain=~openx.com
 .php?zoneid=
 /?zoneid

--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -33,7 +33,22 @@
 !||glbimg.com^*/api/*/api.min.js
 !||glbimg.com^*/cadun.js
 
-!! end GLOBO
+! ESPECÍFICOS PARA A EPOCA.GLOBO.COM
+||revistaquem.globo.com/one-signal/
+||ogjs.infoglobo.com.br^*/*GTM*js
+||ogjs.infoglobo.com.br^*/gallery.js
+||ogjs.infoglobo.com.br^*/observer.js
+||ogjs.infoglobo.com.br^*/advertising.js
+||s3.glbimg.com^*/revistaquem.bundle*.js
+||static.infoglobo.com.br^*/tiny.js
+||static.infoglobo.com.br^*/tools.js
+!! JS para imagens das publicações, porém também carrega 
+!! propagandas e tags de rastreamento
+!||s3.glbimg.com^*/bundle*.js
+!! Barra globo.com
+!||barra.globo.com^*/barra-globocom.min.js
+
+! end GLOBO
 
 &zoneid=*&ad_$popup
 .openx.$domain=~openx.com

--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -2,6 +2,7 @@
 ||recomendacao.globo.com
 ||globo-ab.globo.com
 ||cocoon.globo.com
+||cocoon.qa.globoi.com
 ||sentry.globoi.com
 ||analysis.infoglobo.com.br
 !! RASTREADORES HORIZON, GA, FACEBOOK E COOKIES
@@ -13,6 +14,8 @@
 ||glbimg.com^*/globo-ab-v2.min.js
 ||glbimg.com^*/globo-ab.min.js
 ||glbimg.com^*/glb-rt.js
+||ogjs.infoglobo.com.br^*/*observer*.js
+||ogjs.infoglobo.com.br^*/*advertising*.js
 
 !! OUTROS RASTREADORES E/OU ABORRECIMENTOS
 ||glbimg.com^*/growth.min.js
@@ -33,12 +36,10 @@
 !||glbimg.com^*/api/*/api.min.js
 !||glbimg.com^*/cadun.js
 
-! ESPECÍFICOS PARA A EPOCA.GLOBO.COM
+! ESPECÍFICOS PARA REVISTAQUEM.GLOBO.COM
 ||revistaquem.globo.com/one-signal/
 ||ogjs.infoglobo.com.br^*/*GTM*js
 ||ogjs.infoglobo.com.br^*/gallery.js
-||ogjs.infoglobo.com.br^*/observer.js
-||ogjs.infoglobo.com.br^*/advertising.js
 ||s3.glbimg.com^*/revistaquem.bundle*.js
 ||static.infoglobo.com.br^*/tiny.js
 ||static.infoglobo.com.br^*/tools.js
@@ -47,6 +48,9 @@
 !||s3.glbimg.com^*/bundle*.js
 !! Barra globo.com
 !||barra.globo.com^*/barra-globocom.min.js
+
+! ESPECÍFICOS PARA EPOCA.GLOBO.COM
+||ogjs.infoglobo.com.br^*/infg_id_globoid.js
 
 ! end GLOBO
 

--- a/easylistbrasil/general_block.txt
+++ b/easylistbrasil/general_block.txt
@@ -3,6 +3,7 @@
 ||globo-ab.globo.com
 ||cocoon.globo.com
 ||sentry.globoi.com
+||analysis.infoglobo.com.br
 !! RASTREADORES HORIZON, GA, FACEBOOK E COOKIES
 !! PODEM SER SERVIDOS ATRÁVES DE VÁRIOS CDN DIFERENTES
 ||glbimg.com^*/horizon-client-js.min.js


### PR DESCRIPTION
Como a maioria dos sites da globo utilizam o seu próprio TLD (.globo), esses domínios não serão considerados como thirdparty. Por isso adicionei nesta lista.